### PR TITLE
Inicializar servidor TCP concurrente para go-chat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/tu-usuario/go-chat
+
+go 1.24.3

--- a/main.go
+++ b/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"net"
+	"strings"
+)
+
+func main() {
+	// Listen on port 8080
+	listener, err := net.Listen("tcp", ":8080")
+	if err != nil {
+		log.Fatal("Error al iniciar el servidor:", err)
+	}
+	defer listener.Close()
+
+	fmt.Println("Servidor Go-Chat iniciado en el puerto 8080...")
+
+	for {
+		// Accept incoming connections
+		conn, err := listener.Accept()
+		if err != nil {
+			log.Println("Error al aceptar conexión:", err)
+			continue
+		}
+
+		// Handle connection in a new Goroutine
+		go handleConnection(conn)
+	}
+}
+
+func handleConnection(conn net.Conn) {
+	defer conn.Close()
+
+	// Greet the user
+	fmt.Fprintln(conn, "Bienvenido al servidor Go-Chat!")
+
+	reader := bufio.NewReader(conn)
+	for {
+		// Read message from user
+		message, err := reader.ReadString('\n')
+		if err != nil {
+			log.Printf("Conexión cerrada por el usuario o error: %v\n", err)
+			return
+		}
+
+		// Remove newline and trim space
+		message = strings.TrimSpace(message)
+		if message == "" {
+			continue
+		}
+
+		// Echo the message back to the same user
+		fmt.Fprintf(conn, "[Eco]: %s\n", message)
+	}
+}


### PR DESCRIPTION
He inicializado el módulo Go y creado el servidor TCP concurrente solicitado. El servidor escucha en el puerto 8080 y maneja cada conexión en una goroutine independiente. Cada cliente recibe un saludo de bienvenida y cualquier mensaje enviado es devuelto con el prefijo "[Eco]: ". Las conexiones se cierran correctamente al terminar o ante errores.

Fixes #1

---
*PR created automatically by Jules for task [13052963665378121167](https://jules.google.com/task/13052963665378121167) started by @Villata-dev*